### PR TITLE
Fix DRY Mixin Scoping

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hagrid",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "authors": [
     "felics <hi@felics.me>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hagrid",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/felics/hagrid"

--- a/src/hagrid/_core.scss
+++ b/src/hagrid/_core.scss
@@ -7,15 +7,13 @@
 // 1. https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
 ///////////////////////////////
 
+// * Only carries properties that are not overwritten in modifiers. Rest is added
+// * in @grid-modifiers via conditionals
 @mixin grid-static {
     @include mixin-dryer("grid") {
         display: flex;
         flex: initial;
-        flex-flow: row wrap;
-        align-items: flex-start;
         list-style: none;
-        margin-left: (-$hagrid-gutter/2);
-        margin-right: (-$hagrid-gutter/2);
         padding: 0;
 
         @if $hagrid-fallback and $hagrid-fallback-fontfix {
@@ -23,14 +21,15 @@
             font-family: FreeSans, Arimo, "Droid Sans", Helvetica, Arial, sans-serif;
             text-rendering: optimizespeed;
         }
+        
     }
 }
-
 
 @mixin item-static {
     @include mixin-dryer("item") {
         flex-shrink: 0; // * 1
         box-sizing: border-box;
+
         padding-left: ($hagrid-gutter/2);
         padding-right: ($hagrid-gutter/2);
 

--- a/src/hagrid/_modifiers.scss
+++ b/src/hagrid/_modifiers.scss
@@ -4,9 +4,40 @@
 ///////////////////////////////
 
 @mixin grid-modifiers($modifiers...) {
+
+    $is-y: false;
+    $is-orientation: false;
+    $is-spacing: false;
+
     @each $modifier in $modifiers {
+        // * Check for modifiers that collide with defaults
+        @if $modifier == bottom or $modifier == top or $modifier == middle {
+            $is-y: true;
+        }
+        @else if $modifier == rev or $modifier == x-rev or $modifier == y-rev {
+            $is-orientation: true;
+        }
+        @else if $modifier == narrow or $modifier == wide or $modifier == full {
+            $is-spacing: true;
+        }
+
         @include grid-modifier($modifier);
+
     }
+
+    @if $is-y == false {
+        align-items: flex-start;
+    }
+
+    @if $is-orientation == false {
+        flex-flow: row wrap;
+    }
+
+    @if $is-spacing == false {
+        margin-left: (-$hagrid-gutter/2);
+        margin-right: (-$hagrid-gutter/2);
+    }
+
 }
 
 @mixin grid-modifier($modifier) {
@@ -43,6 +74,7 @@
     }
 
     // * y-Axis Alignment
+    // * We have to use !important on some properties in order to keep the nice syntax
     //////////////////////////////
 
     @else if $modifier == top {
@@ -60,7 +92,7 @@
 
         @if $hagrid-fallback {
             > * {
-                vertical-align: bottom;
+                vertical-align: bottom!important;
             }
         }
 
@@ -70,7 +102,7 @@
 
         @if $hagrid-fallback {
             > * {
-                vertical-align: middle;
+                vertical-align: middle!important;
             }
         }
 
@@ -110,24 +142,24 @@
         margin-left: 0;
         margin-right: 0;
         > * {
-            padding-left: 0;
-            padding-right: 0;
+            padding-left: 0!important;
+            padding-right: 0!important;
         }
     }
     @else if $modifier == wide {
         margin-left: (-$hagrid-gutter);
         margin-right: (-$hagrid-gutter);
         > * {
-            padding-left: $hagrid-gutter;
-            padding-right: $hagrid-gutter;
+            padding-left: $hagrid-gutter!important;
+            padding-right: $hagrid-gutter!important;
         }
     }
     @else if $modifier == narrow {
         margin-left: (-$hagrid-gutter/4);
         margin-right: (-$hagrid-gutter/4);
         > * {
-            padding-left: ($hagrid-gutter/4);
-            padding-right: ($hagrid-gutter/4);
+            padding-left: ($hagrid-gutter/4) !important;
+            padding-right: ($hagrid-gutter/4) !important;
         }
     }
 
@@ -150,6 +182,8 @@
     @else if $modifier == x-rev {
 
         @if $hagrid-fallback {
+            // * Needs to be reset - will be skipped otherwise
+            flex-flow: row wrap;
             direction: rtl;
             text-align: left;
             > * {
@@ -187,5 +221,7 @@
         } @else {
             flex-flow: row-reverse wrap-reverse;
         }
+    } @else {
+        @error "Modifier #{ modifier } does not exist."
     }
 }


### PR DESCRIPTION

Closes #14 

- Only apply default values for margin, flex-flow and align-items if
they are not overwritten

- Default values bound to calling element - better traceability in
output

- Add error if modifier is not matched

- Add important to spacing-modifier children(+fallback:y-axis
modifiers) to prevent overwriting with selector specifity

- Reset flex-flow on fallback x-rev