### PR TITLE
Add config-map for custom gutters

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ By default, the grid is just a light wrapper around flexbox, so go nuts with fle
 
 ### Spacing:
 
- - **narrow:** Half the gutter between items.
- - **wide:** Double the gutter between items.
- - **full:** No gutter between items.
+You can provide custom gutters in the grid via the config-variable `$hagrid-gutters`. Use them as you would use a normal modifier. (e.g. `@include g(wide)`)
 
 ### Direction:
 

--- a/README.md
+++ b/README.md
@@ -28,42 +28,41 @@ bower install hagrid
 
 .parent {
 
-		// * Initialize basic grid
-		@include g;
+	// * Initialize basic grid
+	@include g;
 
-    // * Initialize a grid with a set of modifiers
-    @include g(full, rev);
+	// * Initialize a grid with a set of modifiers
+	@include g(full, rev);
 
-    // * Alternative syntax
-    @include grid(full, rev);
+	// * Alternative syntax
+	@include grid(full, rev);
 
 }
 
 .child {
-    // * Initialize a grid-item with a set of responsive widths
-    // * The general width is set without a breakpoint-keyword (Here: 1/2)
-    // * Responsive widths are set in the config-map $hagrid-breakpoints
-    @include i(1/2, 1/3 md, 1/4 lg);
+	// * Initialize a grid-item with a set of responsive widths
+	// * The general width is set without a breakpoint-keyword (Here: 1/2)
+	// * Responsive widths are set in the config-map $hagrid-breakpoints
+	@include i(1/2, 1/3 md, 1/4 lg);
 
-    // * If you initialize the item without arguments or a general width, it defaults to 100% (mobile first)
-    @include i;
-    @include i(2/3 md, 3/4 lg);
+	// * If you initialize the item without arguments or a general width, it defaults to 100% (mobile first)
+	@include i;
+	@include i(2/3 md, 3/4 lg);
 
-    // * You can use whatever you want as values.
-    // * Fractions work great for grids and allow infinite columns without doing math.
-    // * Passing in false will prevent @i from setting any general width (Responsive widths are false by default)
-    // * using false/static values can be cool in combination with the "auto"-modifier
+	// * You can use whatever you want as values.
+	// * Fractions work great for grids and allow infinite columns without doing math.
+	// * Passing in false will prevent @i from setting any general width (Responsive widths are false by default)
+	// * using false/static values can be cool in combination with the "auto"-modifier
 
-    // * Recommended
-    @include i(1/2, 1/3 md, 1/4 lg);
+	// * Recommended
+	@include i(1/2, 1/3 md, 1/4 lg);
 
-    //* Possible
-    @include i(false, lg 50%);
+	//* Possible
+	@include i(false, lg 50%);
 
-    // * Alternative syntax
-    @include item();
+	// * Alternative syntax
+	@include item();
 }
-
 ```
 
 By default, the grid is just a light wrapper around flexbox, so go nuts with flexbox. Note: `display: flex` is only set on the grid, so you may have to re-set it on grid-items and children.
@@ -90,23 +89,23 @@ By default, the grid is just a light wrapper around flexbox, so go nuts with fle
 ```scss
 
 .auto-grid {
-    @include g(auto);
-    // Auto-Layout all
-    > .item {
-        @include i(false);
-    }
+	@include g(auto);
+	// Auto-Layout all
+	> .item {
+		@include i(false);
+	}
 }
 
 .auto-grid {
-    @include g(auto);
-    // Auto-Layout around one static
-    > .item {
-        @include i(false);
-    }
-    > .item.first {
-        @include i(240px);
-        max-width: 240px;
-    }
+	@include g(auto);
+	// Auto-Layout around one static
+	> .item {
+		@include i(false);
+	}
+	> .item.first {
+		@include i(240px);
+		max-width: 240px;
+	}
 }
 
 ```
@@ -135,11 +134,11 @@ You can provide custom gutters in the grid via the config-variable `$hagrid-gutt
 ```scss
 
 .stretch {
-    @include g();
-    > .item {
-        @include i();
-        @include stretch;
-    }
+	@include g;
+	> .item {
+		@include i;
+		@include stretch;
+	}
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ bower install hagrid
 ```scss
 
 .parent {
+
+		// * Initialize basic grid
+		@include g;
+
     // * Initialize a grid with a set of modifiers
     @include g(full, rev);
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ bower install hagrid
 By default, the grid is just a light wrapper around flexbox, so go nuts with flexbox. Note: `display: flex` is only set on the grid, so you may have to re-set it on grid-items and children.
 
 ## Options:
- - `$hagrid-gutter`: Set the gutter between items.
+ - `$hagrid-gutters`: Specify gutters between items. They are used like modifiers or applied to all grids (default). (see below)
  - `$hagrid-breakpoints`: Set the breakpoints. Can be used with the @bp-mixin too.
  - `$hagrid-fallback`: If you want to add an `inline-block`-grid for older browsers, set this to true. By default, the whitespace issue is fixed the [pure](http://purecss.io)-way via letter-spacing / font-family. You have to reset item-font with `$hagrid-fallback-font`. If you want to fix the issue via 0-whitespace HTML, set `$hagrid-fallback-fontfix` to false
  - `$hagrid-fallback-warnings:` Displays warnings about modifiers / mixins that won't work on the fallback

--- a/__test__/src/scss/test.scss
+++ b/__test__/src/scss/test.scss
@@ -16,7 +16,7 @@ body {
 
 .block {
     // * Behave like a grid-item
-    @include i();
+    @include i;
     background: $color-secondary;
     border: 1px solid $color-border;
     box-shadow: inset 0 0 .5em .5em rgba($color-shade, .1);

--- a/__test__/src/scss/tests/_modifiers.scss
+++ b/__test__/src/scss/tests/_modifiers.scss
@@ -1,7 +1,7 @@
 .modifier {
 
     &-grid {
-        @include g();
+        @include g;
     }
 
     &-item {
@@ -15,7 +15,7 @@
     }
 
     &-header {
-        @include i();
+        @include i;
     }
 
     &-right {
@@ -38,7 +38,7 @@
         @include g(auto);
 
         .modifier-header {
-            @include i();
+            @include i;
         }
 
         .auto-item {
@@ -66,7 +66,7 @@
     }
 
     &-stretch {
-        @include g();
+        @include g;
 
         > .modifier-item {
             @include stretch;

--- a/__test__/src/scss/tests/_pushpull.scss
+++ b/__test__/src/scss/tests/_pushpull.scss
@@ -1,6 +1,6 @@
 .push {
     &-container {
-        @include g();
+        @include g;
         margin-bottom: 1.5rem;
     }
 

--- a/__test__/src/scss/tests/_widths.scss
+++ b/__test__/src/scss/tests/_widths.scss
@@ -1,11 +1,11 @@
 .widths {
     &-container {
-        @include g();
+        @include g;
         margin-bottom: 1.5rem;
     }
 
     &-item {
-        @include i();
+        @include i;
     }
 
     &-column {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hagrid",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "authors": [
     "felics <hi@felics.me>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hagrid",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/_hagrid.scss
+++ b/src/_hagrid.scss
@@ -8,10 +8,16 @@
 // Configuration
 //////////////////////////////
 
-// * Set the default gutter
+// * Set gutters
+// * do not delete default!
 //////////////////////////////
 
-$hagrid-gutter: 1.5rem;
+$hagrid-gutters: (
+    default: 1.5rem,
+    full: 0,
+    narrow: 0.5rem,
+    wide: 3rem
+);
 
 // * Breakpoints
 // * Can be used for the grid e.g. (@include i(breakpoint 2/3))

--- a/src/hagrid/_core.scss
+++ b/src/hagrid/_core.scss
@@ -28,10 +28,6 @@
     @include mixin-dryer("item") {
         box-sizing: border-box;
         flex-shrink: 0; // * 1
-        padding: {
-            left: ($hagrid-gutter/2);
-            right: ($hagrid-gutter/2);
-        };
 
         @if $hagrid-fallback {
             display: inline-block;
@@ -58,7 +54,7 @@
 
 @mixin grid($modifiers...) {
 
-    @include grid-static();
+    @include grid-static;
 
     @include grid-modifiers($modifiers...);
 }
@@ -68,7 +64,7 @@
 
 @mixin item($widths...) {
 
-    @include item-static();
+    @include item-static;
 
     @include grid-calc(width, $widths...);
 }
@@ -79,14 +75,14 @@
 
 @mixin pull($widths...) {
 
-    @include push-pull-static();
+    @include push-pull-static;
 
     @include grid-calc(right, $widths...);
 }
 
 @mixin push($widths...) {
 
-    @include push-pull-static();
+    @include push-pull-static;
 
     @include grid-calc(left, $widths...);
 }

--- a/src/hagrid/_functions.scss
+++ b/src/hagrid/_functions.scss
@@ -79,7 +79,7 @@ $hagrid-placeholders: ();
                 $width-detected: true;
             }
             // * If false is passed, assign no width
-            @else if $width == false {
+            @elseif $width == false {
                 $width-detected: true;
             }
             // * Handle responsive args

--- a/src/hagrid/_functions.scss
+++ b/src/hagrid/_functions.scss
@@ -122,6 +122,17 @@ $hagrid-placeholders: ();
     }
 }
 
+// Gutter Modifier Functions
+//////////////////////////////
+
+@function hagrid-gutter-exists($id) {
+    @return map-has-key($hagrid-gutters, $id);
+}
+
+@function hagrid-gutter-get($id) {
+    @return map-get($hagrid-gutters, $id);
+}
+
 // Shorthands
 //////////////////////////////
 

--- a/src/hagrid/_modifiers.scss
+++ b/src/hagrid/_modifiers.scss
@@ -5,20 +5,21 @@
 
 @mixin grid-modifiers($modifiers...) {
 
+
     $is-y: false;
     $is-wrap: false;
-    $is-spacing: false;
+    $is-not-spacing: true;
 
     @each $modifier in $modifiers {
         // * Check for modifiers that collide with defaults
         @if $modifier == bottom or $modifier == top or $modifier == middle {
             $is-y: true;
         }
-        @else if $modifier == flip {
+        @elseif $modifier == flip {
             $is-wrap: true;
         }
-        @else if $modifier == narrow or $modifier == wide or $modifier == full {
-            $is-spacing: true;
+        @elseif hagrid-gutter-exists($modifier) {
+            $is-not-spacing: false;
         }
 
         @include grid-modifier($modifier);
@@ -33,11 +34,19 @@
         flex-wrap: wrap;
     }
 
-    @if $is-spacing == false {
+    @if $is-not-spacing == true {
+        $gutter: hagrid-gutter-get(default);
         margin: {
-            left: (-$hagrid-gutter/2);
-            right: (-$hagrid-gutter/2);
+            left: -$gutter / 2;
+            right: -$gutter / 2;
         };
+
+        > * {
+            padding: {
+                left: $gutter / 2;
+                right: $gutter / 2;
+            };
+        }
     }
 }
 
@@ -113,46 +122,6 @@
     // Spacing
     //////////////////////////////
 
-    @else if $modifier == full {
-        margin: {
-            left: 0;
-            right: 0;
-        };
-
-        > * {
-            padding: {
-                left: 0!important;
-                right: 0!important;
-            };
-        }
-    }
-    @else if $modifier == wide {
-        margin: {
-            left: (-$hagrid-gutter);
-            right: (-$hagrid-gutter);
-        };
-
-        > * {
-            padding: {
-                left: $hagrid-gutter!important;
-                right: $hagrid-gutter!important;
-            };
-        }
-    }
-    @else if $modifier == narrow {
-        margin: {
-            left: (-$hagrid-gutter/4);
-            right: (-$hagrid-gutter/4);
-        };
-
-        > * {
-            padding: {
-                left: ($hagrid-gutter/4)!important;
-                right: ($hagrid-gutter/4)!important;
-            };
-        }
-    }
-
     // Flex Spacing
     ///////////////////////////////
 
@@ -195,6 +164,26 @@
         }
     }
     @else {
-        @error "Modifier #{ $modifier } does not exist."
+
+        @if hagrid-gutter-exists($modifier) {
+            $gutter: hagrid-gutter-get($modifier);
+
+            margin: {
+                left: -$gutter / 2;
+                right: -$gutter / 2;
+            };
+
+            > * {
+                padding: {
+                    left: $gutter / 2;
+                    right: $gutter / 2;
+                };
+            }
+
+        }
+        @else {
+            @error "Modifier #{ $modifier } does not exist.";
+        }
+
     }
 }

--- a/src/hagrid/_modifiers.scss
+++ b/src/hagrid/_modifiers.scss
@@ -56,7 +56,7 @@
             }
         }
     }
-    @else if $modifier == center {
+    @elseif $modifier == center {
         justify-content: center;
 
         @if $hagrid-fallback {
@@ -71,7 +71,7 @@
     // * We have to use !important on some properties in order to keep the nice syntax
     //////////////////////////////
 
-    @else if $modifier == bottom {
+    @elseif $modifier == bottom {
         align-items: flex-end;
 
         @if $hagrid-fallback {
@@ -81,7 +81,7 @@
         }
 
     }
-    @else if $modifier == middle {
+    @elseif $modifier == middle {
         align-items: center;
 
         @if $hagrid-fallback {
@@ -95,14 +95,14 @@
     // Flex Alignment
     ///////////////////////////////
 
-    @else if $modifier == space-around {
+    @elseif $modifier == space-around {
         justify-content: space-around;
 
         @if $hagrid-fallback and $hagrid-fallback-warnings {
             @warn "Modifier #{$modifier} won't work on fallback-grid!"
         }
     }
-    @else if $modifier == space-between {
+    @elseif $modifier == space-between {
         justify-content: space-between;
 
         @if $hagrid-fallback and $hagrid-fallback-warnings {
@@ -156,7 +156,7 @@
     // Flex Spacing
     ///////////////////////////////
 
-    @else if $modifier == auto {
+    @elseif $modifier == auto {
         > * {
             flex: 1 1 auto;
         }
@@ -169,7 +169,7 @@
     // Direction
     ///////////////////////////////
 
-    @else if $modifier == rev {
+    @elseif $modifier == rev {
 
         @if $hagrid-fallback {
             direction: rtl;
@@ -183,7 +183,7 @@
 
     }
 
-    @else if $modifier == flip {
+    @elseif $modifier == flip {
         flex-wrap: wrap-reverse;
         // * Workaround for IE rendering diff, see: https://github.com/felics/hagrid/issues/13
         @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {


### PR DESCRIPTION
 - Specify custom gutters in `$hagrid-gutters` and use them as you would use normal modifiers
 - Removes the need to use `!important` when setting custom gutters on grids.
 - Update codebase to use shortest mixin-calls when possible
 - Update codebase to use @elseif instead of @else if