### PR TITLE
Fix negative margins causing horizontal-scrollbars

### DIFF
--- a/__test__/src/jade/_tests/widths.jade
+++ b/__test__/src/jade/_tests/widths.jade
@@ -33,7 +33,6 @@ block content
         article.widths-item.three-four
           div.block
 
-
       // 5
       section.widths-container
         article.widths-item.one-five
@@ -72,4 +71,3 @@ block content
           div.block
         article.widths-item.one-ten
           div.block
-

--- a/__test__/src/scss/test.scss
+++ b/__test__/src/scss/test.scss
@@ -10,7 +10,6 @@ $color-border: #3D051A;
 @import "tests/modifiers";
 
 body {
-    margin: 2em;
     background: $color-primary;
 }
 

--- a/__test__/src/scss/tests/_widths.scss
+++ b/__test__/src/scss/tests/_widths.scss
@@ -58,7 +58,7 @@
     display: none;
     @include i(1, lg 5/6);
     @include bp(lg) {
-        display: block;
+        display: inline-block;
     }
 }
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hagrid",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "authors": [
     "felics <hi@felics.me>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hagrid",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/hagrid/_modifiers.scss
+++ b/src/hagrid/_modifiers.scss
@@ -36,16 +36,14 @@
 
     @if $is-not-spacing == true {
         margin: {
-            left: -$gutter / 2;
-            right: -$gutter / 2;
+            left: -$gutter;
         };
     }
 
     #{$hagrid-child-selector} {
         @if $is-not-spacing == true {
             padding: {
-                left: $gutter / 2;
-                right: $gutter / 2;
+                left: $gutter;
             };
         }
         @if $is-y == false and $hagrid-fallback {
@@ -159,14 +157,12 @@
             $gutter: hagrid-gutter-get($modifier);
 
             margin: {
-                left: -$gutter / 2;
-                right: -$gutter / 2;
+                left: -$gutter;
             };
 
             #{$hagrid-child-selector} {
                 padding: {
-                    left: $gutter / 2;
-                    right: $gutter / 2;
+                    left: $gutter;
                 };
             }
 


### PR DESCRIPTION
 - Close #28 
 - Remove `margin-right` & `padding-right` for all grids
 - Removes horizontal scrollbars on body
 - **Confirmation needed:** Does the grid render correctly in all cases? This was one of the things hagrid inherited from csswizardry-grids
 - **Confirmation needed:** Does the grid render without bars when the browser is set to rtl?

#### Tests cleared

 - [x] Chrome OSX
 - [x] Safari OSX
 - [x] Firefox OSX
 - [x] Android 4.0-4.4
 - [x] IE9, IE11, Edge 20
 - [x] iOS 9
